### PR TITLE
Fixing wrong prop placement on shared stops

### DIFF
--- a/SharedStops/LoadingExtension.cs
+++ b/SharedStops/LoadingExtension.cs
@@ -24,6 +24,7 @@ namespace SharedStopEnabler
             {
                 if (!Singleton<SharedStopsTool>.exists)
                     Singleton<SharedStopsTool>.Ensure();
+                Singleton<SharedStopsTool>.instance.Start();
 
                 var assembly = Assembly.GetExecutingAssembly();
                 harmony.PatchAll(assembly);
@@ -32,16 +33,6 @@ namespace SharedStopEnabler
             catch (Exception e)
             {
                 Log.Error($"Failed deploying Patches: {e}");
-            }
-
-            try
-            {
-                EnableElevatedStops();
-                Log.Info($"elevated stops enabled");
-            }
-            catch (Exception e)
-            {
-                Log.Error($"Failed enabling elevated stops: {e}");
             }
         }
         public override void OnLevelUnloading()
@@ -63,60 +54,6 @@ namespace SharedStopEnabler
         public override void OnReleased()
         {
             UnityEngine.Object.DestroyImmediate(Singleton<SharedStopsTool>.instance);
-        }
-
-        private void EnableElevatedStops()
-        {
-            NetInfo[] networks = Resources.FindObjectsOfTypeAll<NetInfo>();
-            foreach (var network in networks)
-            {
-                if (!network.m_hasPedestrianLanes) continue;
-                RoadAI ai = network.m_netAI as RoadAI;
-                if (ai == null) continue;
-                bool hasStops = false;
-                foreach (NetInfo.Lane lane in network.m_lanes)
-                {
-                    if (lane.m_stopType != VehicleInfo.VehicleType.None)
-                    {
-                        hasStops = true;
-                        break;
-                    }
-                }
-                if (!hasStops) continue;
-
-                VehicleInfo.VehicleType firstStopType = network.m_lanes[network.m_sortedLanes[0]].m_stopType;
-                VehicleInfo.VehicleType secondStopType = network.m_lanes[network.m_sortedLanes[network.m_sortedLanes.Length - 1]].m_stopType;
-                VehicleInfo.VehicleType middleStopType = VehicleInfo.VehicleType.None;
-
-                for (int i = 1; i < network.m_lanes.Length - 2; i++)
-                {
-                    if (network.m_lanes[network.m_sortedLanes[i]].m_laneType == NetInfo.LaneType.Pedestrian)
-                    {
-                        middleStopType = network.m_lanes[network.m_sortedLanes[i]].m_stopType;
-                        break;
-                    }
-                }
-                EnableStops(ai.m_elevatedInfo, firstStopType, middleStopType, secondStopType);
-                EnableStops(ai.m_bridgeInfo, firstStopType, middleStopType, secondStopType);
-                EnableStops(ai.m_slopeInfo, firstStopType, middleStopType, secondStopType);
-                EnableStops(ai.m_tunnelInfo, firstStopType, middleStopType, secondStopType);
-            }
-        }
-
-        private static void EnableStops(NetInfo info, VehicleInfo.VehicleType firstStopType, VehicleInfo.VehicleType middleStopType, VehicleInfo.VehicleType secondStopType)
-        {
-            if (info == null) return;
-            for (int i = 1; i < info.m_lanes.Length - 2; i++)
-            {
-                if (info.m_lanes[info.m_sortedLanes[i]].m_vehicleType == VehicleInfo.VehicleType.None)
-                {
-                    info.m_lanes[info.m_sortedLanes[i]].m_stopType = middleStopType;
-                }
-            }
-            info.m_lanes[info.m_sortedLanes[0]].m_stopType = firstStopType;
-            info.m_lanes[info.m_sortedLanes[0]].m_stopOffset = 0f;
-            info.m_lanes[info.m_sortedLanes[info.m_sortedLanes.Length - 1]].m_stopType = secondStopType;
-            info.m_lanes[info.m_sortedLanes[info.m_sortedLanes.Length - 1]].m_stopOffset = 0f;
         }
 
         private void RemoveLaneProp(NetInfo netInfo, string propName)

--- a/SharedStops/SharedStopEnabler.csproj
+++ b/SharedStops/SharedStopEnabler.csproj
@@ -63,6 +63,7 @@
     <Compile Include="LoadingExtension.cs" />
     <Compile Include="SharedStops.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StopSelection\ElevatedStops.cs" />
     <Compile Include="StopSelection\Patch\TransportLinePatch.cs" />
     <Compile Include="StopSelection\SharedStopsTool.cs" />
     <Compile Include="StopSelection\StopSelectionExtensions.cs" />

--- a/SharedStops/StopSelection/ElevatedStops.cs
+++ b/SharedStops/StopSelection/ElevatedStops.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace SharedStopEnabler.StopSelection
+{
+    static class ElevatedStops
+    {
+        public static void EnableElevatedStops()
+        {
+            NetInfo[] networks = Resources.FindObjectsOfTypeAll<NetInfo>();
+            foreach (var network in networks)
+            {
+                if (!network.m_hasPedestrianLanes) continue;
+                RoadAI ai = network.m_netAI as RoadAI;
+                if (ai == null) continue;
+                bool hasStops = false;
+                foreach (NetInfo.Lane lane in network.m_lanes)
+                {
+                    if (lane.m_stopType != VehicleInfo.VehicleType.None)
+                    {
+                        hasStops = true;
+                        break;
+                    }
+                }
+                if (!hasStops) continue;
+
+                VehicleInfo.VehicleType firstStopType = network.m_lanes[network.m_sortedLanes[0]].m_stopType;
+                VehicleInfo.VehicleType secondStopType = network.m_lanes[network.m_sortedLanes[network.m_sortedLanes.Length - 1]].m_stopType;
+                VehicleInfo.VehicleType middleStopType = VehicleInfo.VehicleType.None;
+
+                for (int i = 1; i < network.m_lanes.Length - 2; i++)
+                {
+                    if (network.m_lanes[network.m_sortedLanes[i]].m_laneType == NetInfo.LaneType.Pedestrian)
+                    {
+                        middleStopType = network.m_lanes[network.m_sortedLanes[i]].m_stopType;
+                        break;
+                    }
+                }
+                EnableStops(ai.m_elevatedInfo, firstStopType, middleStopType, secondStopType);
+                EnableStops(ai.m_bridgeInfo, firstStopType, middleStopType, secondStopType);
+                EnableStops(ai.m_slopeInfo, firstStopType, middleStopType, secondStopType);
+                EnableStops(ai.m_tunnelInfo, firstStopType, middleStopType, secondStopType);
+            }
+        }
+
+        private static void EnableStops(NetInfo info, VehicleInfo.VehicleType firstStopType, VehicleInfo.VehicleType middleStopType, VehicleInfo.VehicleType secondStopType)
+        {
+            if (info == null) return;
+            for (int i = 1; i < info.m_lanes.Length - 2; i++)
+            {
+                if (info.m_lanes[info.m_sortedLanes[i]].m_vehicleType == VehicleInfo.VehicleType.None)
+                {
+                    info.m_lanes[info.m_sortedLanes[i]].m_stopType = middleStopType;
+                }
+            }
+            info.m_lanes[info.m_sortedLanes[0]].m_stopType = firstStopType;
+            info.m_lanes[info.m_sortedLanes[0]].m_stopOffset = 0f;
+            info.m_lanes[info.m_sortedLanes[info.m_sortedLanes.Length - 1]].m_stopType = secondStopType;
+            info.m_lanes[info.m_sortedLanes[info.m_sortedLanes.Length - 1]].m_stopOffset = 0f;
+        }
+    }
+}

--- a/SharedStops/StopSelection/SharedStopsTool.cs
+++ b/SharedStops/StopSelection/SharedStopsTool.cs
@@ -20,6 +20,43 @@ namespace SharedStopEnabler.StopSelection
 
         private int m_building => (int)typeof(TransportTool).GetField("m_building", BindingFlags.Public | BindingFlags.Instance).GetValue(Singleton<TransportTool>.instance);
 
+        public void Start()
+        {
+            try
+            {
+                ElevatedStops.EnableElevatedStops();
+                SetLaneProps("Tram Stop");
+                Log.Info($"successful startup");
+            }
+            catch (Exception e)
+            {
+                Log.Error($"Failed on startup {e}");
+            }
+        }
+
+        private void SetLaneProps(string propName)
+        {
+            for (uint i = 0; i < PrefabCollection<NetInfo>.LoadedCount(); i++)
+            {
+                var netInfo = PrefabCollection<NetInfo>.GetLoaded(i);
+
+                if (netInfo == null || netInfo.m_lanes == null || !netInfo.m_hasPedestrianLanes) continue;
+
+                foreach (NetInfo.Lane lane in netInfo.m_lanes)
+                {
+                    if (lane == null || lane.m_laneType != NetInfo.LaneType.Pedestrian || lane.m_laneProps == null || lane.m_laneProps.m_props == null ) continue;
+
+                    foreach (NetLaneProps.Prop laneProp in lane.m_laneProps.m_props)
+                    {
+                        if (laneProp != null && laneProp.m_prop != null && laneProp.m_prop.name == propName)
+                        {
+                            laneProp.m_flagsForbidden |= NetLane.Flags.Stop;
+                        }
+                    }
+                }
+            }
+        }
+
         public bool GetStopPosition(TransportInfo info, ushort segment, ushort building, ushort firstStop, ref Vector3 hitPos, out bool fixedPlatform)
         {
             bool alternateMode = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);


### PR DESCRIPTION
This should get rid of all wrong placed prop such as shelters, stop signs, etc.
- [x] tram shelter on ETT custom road #2
- [ ] wrong props on shared trolleybus stops (steam-comment)